### PR TITLE
Fix capitalization and formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,9 @@
 A framework for creating TUI SSH programs in Rust, powered by [ratatui](https://github.com/ratatui/ratatui) and [russh](https://github.com/Eugeny/russh).
 
 ## Why Chai
-The Chai framework makes it easy to host your ratatui TUI apps on an ssh server.
+The Chai framework makes it easy to host your ratatui TUI apps on an SSH server.
 
 First, encapsulate your TUI program within a stateful struct. Then, implement the `ChaiApp` trait for this struct to satisfy the required interface abstractions. After that, it's simple plug-and-play by providing your new struct to the `ChaiServer`.
-
-For examples, see [here](https://github.com/kllarena07/chai/tree/main/examples).
 ```
 mod app;
 use app::MyApp; // your TUI program
@@ -25,5 +23,7 @@ async fn main() {
     server.run(config).await.expect("Failed running server");
 }
 ```
+
+For examples, see [here](https://github.com/kllarena07/chai/tree/main/examples).
 
 _Made with ❤️ by [krayondev](https://x.com/krayondev)_


### PR DESCRIPTION
Corrected capitalization of 'SSH' and adjusted formatting.